### PR TITLE
Laravel 5.2 update

### DIFF
--- a/src/MemcacheStore.php
+++ b/src/MemcacheStore.php
@@ -46,6 +46,23 @@ class MemcacheStore extends TaggableStore implements Store {
 	}
 
 	/**
+	 * Retrieve multiple items from the cache by key.
+	 *
+	 * Items not found in the cache will have a null value.
+	 *
+	 * @param  array $keys
+	 * @return array
+	 */
+	public function many(array $keys)
+	{
+		$return = [];
+		foreach ($keys as $key) {
+			$return[$key] = $this->get($key);
+		}
+		return $return;
+	}
+
+	/**
 	 * Store an item in the cache for a given number of minutes.
 	 *
 	 * @param  string  $key
@@ -56,6 +73,20 @@ class MemcacheStore extends TaggableStore implements Store {
 	public function put($key, $value, $minutes)
 	{
 		$this->memcache->set($this->prefix.$key, $value, false, $minutes * 60);
+	}
+
+	/**
+	 * Store multiple items in the cache for a given number of minutes.
+	 *
+	 * @param  array $values
+	 * @param  int $minutes
+	 * @return void
+	 */
+	public function putMany(array $values, $minutes)
+	{
+		foreach ($values as $key => $value) {
+			$this->put($key, $value, $minutes);
+		}
 	}
 
     /**


### PR DESCRIPTION
They changed the signature of the Store interface in Laravel 5.2 and now 2 methods are missing (many & putMany)

Related links:
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Contracts/Cache/Store.php
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Cache/RedisStore.php#L101-L117
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Cache/RedisStore.php#L59-L82